### PR TITLE
make room for different DNS management backends

### DIFF
--- a/cmd/set.go
+++ b/cmd/set.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/fgiudici/ddflare/pkg/cflare"
 	"github.com/fgiudici/ddflare/pkg/ddns"
 	"github.com/fgiudici/ddflare/pkg/net"
 	"github.com/urfave/cli/v2"
@@ -64,8 +65,10 @@ func newSetCommand() *cli.Command {
 			}
 			zoneName := domain[len(domain)-2] + "." + domain[len(domain)-1]
 
-			ddns := ddns.Cloudflare{}
-			if err := ddns.New(token); err != nil {
+			// cflare is the only backend right now
+			var ddns ddns.Recorder = cflare.New()
+
+			if err := ddns.Init(token); err != nil {
 				return err
 			}
 

--- a/pkg/cflare/cflare.go
+++ b/pkg/cflare/cflare.go
@@ -1,0 +1,86 @@
+/*
+Copyright © 2024 Francesco Giudici <francesco.giudici@suse.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cflare
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	cf "github.com/cloudflare/cloudflare-go"
+	"github.com/fgiudici/ddflare/pkg/ddns"
+)
+
+var _ ddns.Recorder = (*Cloudflare)(nil)
+
+type Cloudflare struct {
+	api *cf.API
+}
+
+func New() *Cloudflare {
+	return &Cloudflare{}
+}
+
+func (c *Cloudflare) Init(token string) error {
+	var err error
+	// Never returns error when no options are passed (like in this case)
+	c.api, err = cf.NewWithAPIToken(token)
+	return err
+}
+
+func (c *Cloudflare) Write(record, zone, ip string) error {
+	if c.api == nil {
+		return fmt.Errorf("not authorized")
+	}
+
+	ctx := context.Background()
+
+	zoneID, err := c.api.ZoneIDByName(zone)
+	if err != nil {
+		return err
+	}
+	log.Printf("Zone ID: %s", zoneID)
+	dnsRecs, _, err := c.api.ListDNSRecords(ctx, cf.ZoneIdentifier(zoneID),
+		cf.ListDNSRecordsParams{Name: record})
+	if err != nil {
+		return err
+	}
+	for _, d := range dnsRecs {
+		log.Printf("%+v\n", d)
+	}
+	if len(dnsRecs) > 1 {
+		return fmt.Errorf("found %d matching records", len(dnsRecs))
+	}
+	rec := dnsRecs[0]
+
+	updateRec := cf.UpdateDNSRecordParams{
+		Type:    rec.Type,
+		Name:    rec.Name,
+		Content: ip,
+		Data:    rec.Data,
+		ID:      rec.ID,
+		Tags:    rec.Tags,
+		TTL:     rec.TTL,
+	}
+
+	if rec, err = c.api.UpdateDNSRecord(ctx, cf.ZoneIdentifier(zoneID), updateRec); err != nil {
+		return err
+	}
+	log.Printf("record updated:\n%+v\n", rec)
+
+	return nil
+}

--- a/pkg/cflare/cflare_test.go
+++ b/pkg/cflare/cflare_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package ddns
+package cflare
 
 import (
 	"testing"
@@ -35,19 +35,19 @@ func TestNew(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			cf := Cloudflare{}
-			err := cf.New(tt.token)
+			cflare := New()
+			err := cflare.Init(tt.token)
 			if tt.fails {
 				if err == nil {
-					t.Fatalf("expected failure with token %q but got %+v", tt.token, cf.api)
+					t.Fatalf("expected failure with token %q but got %+v", tt.token, cflare.api)
 				}
 				return
 			}
 			if err != nil {
 				t.Fatalf("unexpected failure: %v", err)
 			}
-			if cf.api.APIToken != tt.token {
-				t.Fatalf("expected token %q but got %q", tt.token, cf.api.APIToken)
+			if cflare.api.APIToken != tt.token {
+				t.Fatalf("expected token %q but got %q", tt.token, cflare.api.APIToken)
 			}
 		})
 	}

--- a/pkg/ddns/ddns.go
+++ b/pkg/ddns/ddns.go
@@ -16,72 +16,12 @@ limitations under the License.
 
 package ddns
 
-import (
-	"context"
-	"fmt"
-	"log"
-
-	cf "github.com/cloudflare/cloudflare-go"
-)
-
 type Record struct {
 	ZoneName string
 	Name     string
 }
 
 type Recorder interface {
-	Write(record, zone string) error
-}
-
-type Cloudflare struct {
-	api *cf.API
-}
-
-func (c *Cloudflare) New(token string) error {
-	var err error
-	c.api, err = cf.NewWithAPIToken(token)
-	return err
-}
-
-func (c *Cloudflare) Write(record, zone, ip string) error {
-	if c.api == nil {
-		return fmt.Errorf("not authorized")
-	}
-
-	ctx := context.Background()
-
-	zoneID, err := c.api.ZoneIDByName(zone)
-	if err != nil {
-		return err
-	}
-	log.Printf("Zone ID: %s", zoneID)
-	dnsRecs, _, err := c.api.ListDNSRecords(ctx, cf.ZoneIdentifier(zoneID),
-		cf.ListDNSRecordsParams{Name: record})
-	if err != nil {
-		return err
-	}
-	for _, d := range dnsRecs {
-		log.Printf("%+v\n", d)
-	}
-	if len(dnsRecs) > 1 {
-		return fmt.Errorf("found %d matching records", len(dnsRecs))
-	}
-	rec := dnsRecs[0]
-
-	updateRec := cf.UpdateDNSRecordParams{
-		Type:    rec.Type,
-		Name:    rec.Name,
-		Content: ip,
-		Data:    rec.Data,
-		ID:      rec.ID,
-		Tags:    rec.Tags,
-		TTL:     rec.TTL,
-	}
-
-	if rec, err = c.api.UpdateDNSRecord(ctx, cf.ZoneIdentifier(zoneID), updateRec); err != nil {
-		return err
-	}
-	log.Printf("record updated:\n%+v\n", rec)
-
-	return nil
+	Init(token string) error
+	Write(record, zone, ip string) error
 }


### PR DESCRIPTION
Right now we just support cloudflare API for the backend management of the DNS records. Finalize the ddns interface to abstract cloudflare API access and be ready for alternative DNS management backends.

Fixes: #7