### PR TITLE
containers: drop the 'v' from the tag

### DIFF
--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -55,12 +55,12 @@ jobs:
       - name: Retrieve tag name (main branch)
         if: ${{ startsWith(github.ref, 'refs/heads/main') }}
         run: |
-          echo TAG_NAME=latest >> $GITHUB_ENV
+          echo TAG_NAME="dev-${{ github.sha }}" >> $GITHUB_ENV
           echo VERSION="dev-${{ github.sha }}" >> $GITHUB_ENV
       - name: Retrieve tag name (tag)
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: |
-          echo TAG_NAME=$(echo $GITHUB_REF | sed -e "s|refs/tags/||") >> $GITHUB_ENV
+          echo TAG_NAME=$(echo $GITHUB_REF | sed -e "s|refs/tags/v||") >> $GITHUB_ENV
           echo VERSION=$(echo $GITHUB_REF | sed -e "s|refs/tags/||") >> $GITHUB_ENV
       - name: Build and push container image
         if: ${{ inputs.push-image }}

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GIT_COMMIT?=$(shell git rev-parse --short HEAD)
 GIT_VERSION?=$(shell git describe --tags 2>/dev/null || echo "v0.0.0-"$(GIT_COMMIT))
 IMG_REG?=ghcr.io
 IMG_REPO?=fgiudici/ddflare
-IMG_TAG?=$(GIT_VERSION)
+IMG_TAG?=$(GIT_VERSION:v%=%)
 
 export ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 BUILD_DIR   := bin


### PR DESCRIPTION
keep it for the binary version but drop it from the tags when building the containers 