### PR TITLE
Fix container image build workflow

### DIFF
--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -70,7 +70,7 @@ jobs:
           context: .
           file: ./Dockerfile
           build-args: VERSION=${{ env.VERSION }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           sbom: true
           provenance: mode=max


### PR DESCRIPTION
drop ARMv6 build as base containers are not supported.

Fixes #6029589aeac5df1f54ad2ed0fa390970340332bc