### PR TITLE
README: update with DynDNS update protocol usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,25 @@
   [![example workflow](https://github.com/fgiudici/ddflare/actions/workflows/container-image.yaml/badge.svg)](https://github.com/fgiudici/ddflare/actions/workflows/container-image.yaml)
 </h1>
 
-ddflare is a client to manage DNS type A records via the [Cloudflare API](https://developers.cloudflare.com/api/).
+ddflare provides a [DDNS (Dynamic DNS)](https://en.wikipedia.org/wiki/Dynamic_DNS) client that allows DNS type A record updates via the [DynDNS update prococol v3](https://help.dyn.com/remote-access-api/perform-update/) or via the [Cloudflare API](https://developers.cloudflare.com/api/).
 
-It's primary usage is to provide a [DDNS (Dynamic DNS)](https://en.wikipedia.org/wiki/Dynamic_DNS) client leveraging the Cloudflare API.
 
->[!IMPORTANT]
->Since ddflare operates via the [Cloudflare APIs](https://developers.cloudflare.com/api/),
->ddflare can update dns records for domains managed by Cloudflare only: this means
->your domain has been registered at or transfered to Cloudflare.
+>[!NOTE]
+>ddflare acts as a client for Dynamic DNS services. You can used ddflare with yor Cloudflare registered
+>DNS domain via the [Cloudflare API](https://developers.cloudflare.com/api/) or register to a Dynamic DNS
+>service provider (e.g., [No-IP](https://www.noip.com), [Dyn](https://account.dyn.com/), ...) and update
+>your DNS name via the [DynDNS update prococol v3](https://help.dyn.com/remote-access-api/).
+>
+>The [DynDNS update prococol v3](https://help.dyn.com/remote-access-api/) is a HTTP based API introduced
+>back in the day by dyndns.org (now [Dyn](https://account.dyn.com/), part of Oracle) which is used by
+>many of the available DDNS service providers.
 
-ddflare allows to:
-* retrieve the current public IP address
-* update domain names (FQDNs, recorded as type A records) to point to the current public address (or a custom IP)
-* resolve any domain name (acting as a DNS client)
+While ddflare main functionality is to run in a loop to update the target FQDN to the current public IP
+when a change is detected, it allows to:
+* retrieve and display the current public IP address
+* update a target domain name (FQDN, recorded as a type A record) to point to the current public address
+(or a custom IP)
+* resolve any domain name (acting as a simple DNS client)
 
 <br>
 
@@ -34,22 +40,45 @@ wget https://github.com/fgiudici/ddflare/releases/download/v0.1.0/ddflare-linux-
 sudo install ddflare-linux-amd64 /usr/local/bin/ddflare
 ```
 
-If you prefer a container image, you can pull ddflare from the github repository and run it
-via docker as usual:
+Container images are availble as well on the github repository. Run ddflare
+via docker with:
 
 ```bash
-docker run -ti --rm ghcr.io/fgiudici/ddflare
+docker run -ti --rm ghcr.io/fgiudici/ddflare:0.3.0
 ```
 
-Usage
+Quickstart
 ====
-ddflare has two main commands: `get`, to retrieve the current public IP address
-(or resolve the FQDN passed as argument), and `set`, to update the type A record of the target FQDN
-to the current public ip (or a custom IP address).
+ddflare has two main commands:  `set`, to update the type A record of the target FQDN
+to the current public ip (or a custom IP address) and `get`, to retrieve the current public IP address
+(or resolve the FQDN passed as argument), and
 
 Run `ddflare help` to display all the available commands and flags.
 
-Update domain name to current public IP address ([DDNS client](https://en.wikipedia.org/wiki/Dynamic_DNS))
+Update domain name via [DynDNS update prococol v3](https://help.dyn.com/remote-access-api/)
+----
+>[!NOTE]
+>You should register to the DDNS service first, select your FQDN and retrieve the _username_ and _password_
+>required to authenticate to the service
+
+To update a domain name (FQDN, type A record) to the current public IP address of the host run:
+
+```bash
+ddflare set -s <DDNS_URL> -t <AUTH_TOKEN> <FQDN>
+```
+where `<DDNS_URL>` is the http endpoint of the DDNS service,
+`<FQDN>` is the domain to be updated and `<AUTH_TOKEN>` is the API authentication token.
+
+Real example with:
+* [No-IP](https://www.noip.com/) DDNS provider
+* `myhost.ddns.net` FQDN
+* user `68816xj`
+* password `v4UMHzugodpE`
+```bash
+ddflare set -s noip -t 68816xj:v4UMHzugodpE  myhost.ddns.net
+```
+
+Update domain name via [Cloudflare API](https://developers.cloudflare.com/api/)
 ----
 >[!TIP]
 >In order to update domain names you need a Cloudflare API token with `Zone.DNS` `Edit` permission.
@@ -73,7 +102,7 @@ ddflare set -t gB1fOLbl2d5XynhfIOJvzX8Y4rZnU5RLPW1hg7cM  myhost.example.com
 >ddflare can <ins>update</ins> existing A records but cannot create new ones, so the record
 >should be created in advance.
 >
->To create an A record see Cloudflare's
+>To create an A type record see Cloudflare's
 >[Manage DNS Records](https://developers.cloudflare.com/dns/manage-dns-records/how-to/create-dns-records/)
 >docs.
 


### PR DESCRIPTION
We now support "standard" DDNS protocol used by many DDNS providers besides the Cloudflare API.
Update the README accordingly.